### PR TITLE
Proev 325 326

### DIFF
--- a/app/src/main/java/ru/myproevent/ui/adapters/event_items/EventScreenItem.kt
+++ b/app/src/main/java/ru/myproevent/ui/adapters/event_items/EventScreenItem.kt
@@ -2,7 +2,6 @@ package ru.myproevent.ui.adapters.event_items
 
 import ru.myproevent.domain.models.entities.TimeInterval
 import ru.myproevent.ui.presenters.events.event.event_screen_items_presenters.forms_header_item_presenters.IHeaderPresenter
-import java.lang.RuntimeException
 import java.util.*
 
 /**
@@ -56,7 +55,7 @@ sealed class EventScreenItem(open val itemId: EVENT_SCREEN_ITEM_ID, val type: It
         override val header: FormsHeader<ListItem>
     ) : ListItem(ItemType.EVENT_DATE_ITEM) {
         override fun compareTo(other: ListItem) = when (other) {
-            is EventDateItem -> (timeInterval.start - other.timeInterval.start).toInt()
+            is EventDateItem -> timeInterval.compareTo(other.timeInterval)
             else -> throw RuntimeException("Отсутствует операция сравнения EventDateItem-а и переданного compareTo аргумента")
         }
     }
@@ -69,7 +68,7 @@ sealed class EventScreenItem(open val itemId: EVENT_SCREEN_ITEM_ID, val type: It
     ) : ListItem(ItemType.NO_ITEMS_PLACEHOLDER) {
         override fun compareTo(other: ListItem) = when (other) {
             is NoItemsPlaceholder -> 0 // TODO: я не понял зачем, но похоже даже если в TreeSet нет элементов, при добавлении первого элемента через .add всё равно вызывается compareTo(видимо сам с собой).
-                                       //       Поэтому реализованно это по сути не нужное сравнение.
+            //       Поэтому реализованно это по сути не нужное сравнение.
             else -> throw RuntimeException("Отсутствует операция сравнения NoItemsPlaceholder-а и переданного compareTo аргумента")
         }
     }
@@ -82,7 +81,7 @@ sealed class EventScreenItem(open val itemId: EVENT_SCREEN_ITEM_ID, val type: It
     ) : ListItem(ItemType.TEXT_BOX), LockableEdit {
         override fun compareTo(other: ListItem) = when (other) {
             is TextBox -> 0 // TODO: я не понял зачем, но похоже даже если в TreeSet нет элементов, при добавлении первого элемента через .add всё равно вызывается compareTo(видимо сам с собой).
-                            //       Поэтому реализованно это по сути не нужное сравнение.
+            //       Поэтому реализованно это по сути не нужное сравнение.
             else -> throw RuntimeException("Отсутствует операция сравнения TextBox-а и переданного compareTo аргумента")
         }
     }

--- a/app/src/main/java/ru/myproevent/ui/fragments/events/event/EventFragment.kt
+++ b/app/src/main/java/ru/myproevent/ui/fragments/events/event/EventFragment.kt
@@ -178,8 +178,8 @@ class EventFragment : BaseMvpFragment<FragmentEventBinding>(FragmentEventBinding
             DATE_PICKER_EDIT_RESULT_KEY,
             this
         ) { _, bundle ->
-            bundle.getParcelable<TimeInterval>(NEW_DATE_KEY)?.let { presenter.addEventDate(it) }
             bundle.getParcelable<TimeInterval>(OLD_DATE_KEY)?.let { presenter.removeDate(it) }
+            bundle.getParcelable<TimeInterval>(NEW_DATE_KEY)?.let { presenter.addEventDate(it) }
         }
     }
 }

--- a/app/src/main/java/ru/myproevent/ui/presenters/events/event/EventPresenter.kt
+++ b/app/src/main/java/ru/myproevent/ui/presenters/events/event/EventPresenter.kt
@@ -322,7 +322,8 @@ class EventPresenter(localRouter: Router, var eventBeforeEdit: Event?) :
             eventScreenListPresenter.eventScreenItems.indexOfFirst { item -> item.itemId == EVENT_SCREEN_ITEM_ID.DATES_HEADER }
         with(eventScreenListPresenter.eventScreenItems[headerPosition] as EventScreenItem.FormsHeader<EventScreenItem.ListItem>) {
             val indexOfItemToRemove =
-                items.indexOfFirst { item -> (item as EventScreenItem.EventDateItem).timeInterval == timeInterval }
+                items.indexOfFirst { item -> 
+                    (item as EventScreenItem.EventDateItem).timeInterval == timeInterval }
             if (indexOfItemToRemove == -1) {
                 throw RuntimeException("Попытка удалить дату(временной интервал), которая отсутствует в датах редактируемого мероприятия.")
             }


### PR DESCRIPTION
Исправлен баг, вызывающий ошибку:
 throw RuntimeException("Попытка удалить дату(временной интервал), которая отсутствует в датах редактируемого мероприятия.")
При попытке изменить или удалить даты из списка трёх и более записей.